### PR TITLE
docs: add Next.js setup and env examples

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
-# Copy this file to .env and set the values for your environment
-PORT=3000
-DB_FILE=library.db
+# Environment variables for the Next.js application
+MONGODB_URI=
+NEXTAUTH_SECRET=
+NEXTAUTH_URL=
+EMAIL_SERVER=
+EMAIL_FROM=

--- a/README.md
+++ b/README.md
@@ -1,52 +1,64 @@
-# PustakaPro
+# Next.js Application Setup
 
-PustakaPro is a lightweight library management web application built with **Node.js**, **Express**, and **SQLite**. It offers a minimal interface to keep track of your books.
+This repository contains a starter stack for building applications with [Next.js](https://nextjs.org/). It uses NextAuth for authentication and MongoDB for persistence.
 
-## Features
+## Installation
 
-- View all stored books
-- Search books by title or author
-- Add new books with title, author and optional publication year
-- Edit or delete existing entries
-- View details of individual books
-- Simple EJS views and CSS for quick customization
-- Production middleware for logging and security
-
-## Requirements
-
-- [Node.js](https://nodejs.org/) 18 or later
-
-## Getting Started
-
-Install dependencies:
+1. Install dependencies:
 
 ```bash
 npm install
 ```
 
-Copy `.env.example` to `.env` and adjust settings if needed.
+2. Copy `.env.example` to `.env` and provide values for `MONGODB_URI`, `NEXTAUTH_SECRET`, `EMAIL_SERVER`, `EMAIL_FROM`, and any other required variables.
 
-Start the server:
+## Development
+
+Start the development server:
+
+```bash
+npm run dev
+```
+
+The app will be available at [http://localhost:3000](http://localhost:3000).
+
+## Building
+
+Create an optimized production build:
+
+```bash
+npm run build
+```
+
+Run the production build locally:
 
 ```bash
 npm start
 ```
 
-The application defaults to `http://localhost:3000`. Use the `PORT` and `DB_FILE` variables in `.env` to customize.
+## Deployment
+
+### Deploying to Vercel
+
+1. Push this project to a Git repository (GitHub, GitLab, etc.).
+2. Sign in to [Vercel](https://vercel.com) and import the repository.
+3. Add the required environment variables in the Vercel dashboard.
+4. Click **Deploy**. Vercel will build the project and provide a deployment URL.
+5. Subsequent pushes to your main branch will trigger automatic redeployments.
+
+Alternatively, you can deploy using the Vercel CLI:
+
+```bash
+npm install -g vercel
+vercel
+```
+
+## Scripts
+
+- `npm run dev` – start the development server.
+- `npm run build` – build the application for production.
+- `npm start` – run the production server.
 
 ## Usage
 
-- Search for books using the form on the home page.
-- Click a book's **View** button to see its details.
-
-## Database
-
-The first run will create a SQLite database file specified by `DB_FILE` (default `library.db`) if one does not already exist. This file is ignored by Git via `.gitignore`.
-
-## Project Structure
-
-- `app.js` – main Express application
-- `views/` – EJS templates for the pages
-- `public/style.css` – modern styling
-
-Additional production middleware includes logging with **morgan** and security headers via **helmet**. A simple 404 page and error handler are also provided.
+Use `npm run dev` during development, then `npm run build` followed by `npm start` for production environments. Deployments to Vercel will automatically run the build and start commands.


### PR DESCRIPTION
## Summary
- replace README with Next.js installation, development, and Vercel deployment docs
- add .env.example listing required environment variables

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68ad6fe53a308322844ca3315d788b4c