### PR TITLE
Add reusable Tailwind UI components with dark mode

### DIFF
--- a/app.js
+++ b/app.js
@@ -14,6 +14,7 @@ const db = new sqlite3.Database(DB_FILE);
 app.set('view engine', 'ejs');
 app.set('views', path.join(__dirname, 'views'));
 app.use(express.static(path.join(__dirname, 'public')));
+app.use('/components', express.static(path.join(__dirname, 'components')));
 app.use(bodyParser.urlencoded({ extended: false }));
 app.use(helmet());
 app.use(morgan('combined'));

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+
+/**
+ * Accessible button component styled with TailwindCSS and supporting dark mode.
+ *
+ * @param variant Visual style of the button. Defaults to `primary`.
+ * @param size Size of the button. Defaults to `md`.
+ * @param onClick Callback invoked when the button is activated.
+ * @param children Content of the button.
+ */
+export interface ButtonProps {
+  variant?: 'primary' | 'secondary' | 'danger';
+  size?: 'sm' | 'md' | 'lg';
+  onClick?: React.MouseEventHandler<HTMLButtonElement>;
+  type?: 'button' | 'submit' | 'reset';
+  children: React.ReactNode;
+}
+
+/**
+ * Button component that ensures keyboard accessibility and ARIA role.
+ */
+export const Button: React.FC<ButtonProps> = ({
+  variant = 'primary',
+  size = 'md',
+  onClick,
+  type = 'button',
+  children
+}) => {
+  const base = 'rounded focus:outline-none focus:ring-2 focus:ring-offset-2 font-medium';
+  const variants: Record<string, string> = {
+    primary:
+      'bg-blue-600 text-white hover:bg-blue-700 focus:ring-blue-500 dark:bg-blue-500 dark:hover:bg-blue-400',
+    secondary:
+      'bg-gray-200 text-gray-800 hover:bg-gray-300 focus:ring-gray-400 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600',
+    danger:
+      'bg-red-600 text-white hover:bg-red-700 focus:ring-red-500 dark:bg-red-500 dark:hover:bg-red-400'
+  };
+  const sizes: Record<string, string> = {
+    sm: 'px-2 py-1 text-sm',
+    md: 'px-4 py-2',
+    lg: 'px-6 py-3 text-lg'
+  };
+
+  return (
+    <button
+      type={type}
+      role="button"
+      onClick={onClick}
+      className={`${base} ${variants[variant]} ${sizes[size]}`}
+    >
+      {children}
+    </button>
+  );
+};
+
+export default Button;

--- a/components/ui/Form.tsx
+++ b/components/ui/Form.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import Button from './Button';
+
+/**
+ * Simple form wrapper that forwards submit events and supports Tailwind styling.
+ *
+ * @param onSubmit Callback when the form is submitted.
+ * @param children Form fields to render inside the form.
+ * @param submitLabel Label for the submit button. Defaults to `Submit`.
+ */
+export interface FormProps extends React.FormHTMLAttributes<HTMLFormElement> {
+  submitLabel?: string;
+}
+
+export const Form: React.FC<FormProps> = ({ submitLabel = 'Submit', children, ...rest }) => (
+  <form className="space-y-4" role="form" {...rest}>
+    {children}
+    <Button type="submit">{submitLabel}</Button>
+  </form>
+);
+
+export default Form;

--- a/components/ui/Modal.tsx
+++ b/components/ui/Modal.tsx
@@ -1,0 +1,62 @@
+import React, { useEffect, useRef } from 'react';
+import Button from './Button';
+
+/**
+ * Modal dialog component providing keyboard navigation and ARIA roles.
+ *
+ * @param isOpen Controls visibility of the modal.
+ * @param title Title displayed at the top of the modal.
+ * @param onClose Callback invoked when the modal requests to close.
+ * @param children Modal body content.
+ */
+export interface ModalProps {
+  isOpen: boolean;
+  title: string;
+  onClose: () => void;
+  children: React.ReactNode;
+}
+
+export const Modal: React.FC<ModalProps> = ({ isOpen, title, onClose, children }) => {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    if (isOpen) document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [isOpen, onClose]);
+
+  useEffect(() => {
+    if (isOpen && ref.current) ref.current.focus();
+  }, [isOpen]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="modal-title"
+    >
+      <div
+        ref={ref}
+        tabIndex={-1}
+        className="bg-white dark:bg-gray-800 rounded p-6 w-full max-w-md outline-none"
+      >
+        <h2 id="modal-title" className="text-xl mb-4 text-gray-900 dark:text-gray-100">
+          {title}
+        </h2>
+        <div className="text-gray-700 dark:text-gray-200">{children}</div>
+        <div className="mt-6 text-right">
+          <Button variant="secondary" onClick={onClose}>
+            Close
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Modal;

--- a/components/ui/Table.tsx
+++ b/components/ui/Table.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+
+/**
+ * Generic table component that renders data rows using a render function.
+ *
+ * @param headers Column headers for the table.
+ * @param data Array of data objects to display.
+ * @param renderRow Function that returns table cells for a given row.
+ */
+export interface TableProps<T> {
+  headers: string[];
+  data: T[];
+  renderRow: (item: T, index: number) => React.ReactNode;
+}
+
+export function Table<T>({ headers, data, renderRow }: TableProps<T>) {
+  return (
+    <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700" role="table">
+      <thead className="bg-gray-50 dark:bg-gray-700">
+        <tr>
+          {headers.map((h) => (
+            <th
+              key={h}
+              scope="col"
+              className="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-200 uppercase tracking-wider"
+            >
+              {h}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody className="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
+        {data.map((item, idx) => (
+          <tr key={idx} className="hover:bg-gray-50 dark:hover:bg-gray-700">
+            {renderRow(item, idx)}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+export default Table;

--- a/views/404.ejs
+++ b/views/404.ejs
@@ -1,19 +1,28 @@
 <!DOCTYPE html>
-<html>
+<html class="dark">
 <head>
-    <meta charset="UTF-8">
-    <title>Not Found - PustakaPro</title>
-    <link rel="stylesheet" href="/style.css">
+  <meta charset="UTF-8" />
+  <title>Not Found - PustakaPro</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
 </head>
-<body>
-<div class="container">
-    <header>
-        <h1>Page Not Found</h1>
-        <nav>
-            <a href="/" class="button">Back Home</a>
-        </nav>
-    </header>
-    <p>The requested page could not be found.</p>
-</div>
+<body class="bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-gray-100">
+  <div id="root"></div>
+  <script type="text/babel" data-type="module" data-presets="react,typescript">
+    import Button from '/components/ui/Button.tsx';
+
+    const App = () => (
+      <div className="max-w-md mx-auto p-4 text-center">
+        <h1 className="text-2xl font-bold mb-4">Page Not Found</h1>
+        <p className="mb-4">The requested page could not be found.</p>
+        <Button onClick={() => window.location.href = '/'}>Back Home</Button>
+      </div>
+    );
+
+    const root = ReactDOM.createRoot(document.getElementById('root'));
+    root.render(<App />);
+  </script>
 </body>
 </html>

--- a/views/add.ejs
+++ b/views/add.ejs
@@ -1,24 +1,52 @@
 <!DOCTYPE html>
-<html>
+<html class="dark">
 <head>
-    <meta charset="UTF-8">
-    <title>Add Book - PustakaPro</title>
-    <link rel="stylesheet" href="/style.css">
+  <meta charset="UTF-8" />
+  <title>Add Book - PustakaPro</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
 </head>
-<body>
-<div class="container">
-    <header>
-        <h1>Add Book</h1>
-        <nav>
-            <a href="/" class="button">Home</a>
-        </nav>
-    </header>
-    <form method="post" action="/add">
-        <label>Title:<br><input type="text" name="title" required></label>
-        <label>Author:<br><input type="text" name="author" required></label>
-        <label>Year:<br><input type="number" name="year"></label>
-        <button type="submit">Add</button>
-    </form>
-</div>
+<body class="bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-gray-100">
+  <div id="root"></div>
+  <script type="text/babel" data-type="module" data-presets="react,typescript">
+    import Button from '/components/ui/Button.tsx';
+    import Form from '/components/ui/Form.tsx';
+
+    const App = () => {
+      const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+        // allow normal form submission to server
+      };
+
+      return (
+        <div className="max-w-md mx-auto p-4">
+          <header className="flex items-center justify-between mb-4">
+            <h1 className="text-2xl font-bold">Add Book</h1>
+            <nav>
+              <Button onClick={() => window.location.href = '/'}>Home</Button>
+            </nav>
+          </header>
+          <Form method="post" action="/add" onSubmit={handleSubmit} submitLabel="Add">
+            <label className="block">
+              <span className="block mb-1">Title</span>
+              <input name="title" required className="w-full p-2 border dark:border-gray-600 rounded" />
+            </label>
+            <label className="block">
+              <span className="block mb-1">Author</span>
+              <input name="author" required className="w-full p-2 border dark:border-gray-600 rounded" />
+            </label>
+            <label className="block">
+              <span className="block mb-1">Year</span>
+              <input name="year" type="number" className="w-full p-2 border dark:border-gray-600 rounded" />
+            </label>
+          </Form>
+        </div>
+      );
+    };
+
+    const root = ReactDOM.createRoot(document.getElementById('root'));
+    root.render(<App />);
+  </script>
 </body>
 </html>

--- a/views/edit.ejs
+++ b/views/edit.ejs
@@ -1,24 +1,48 @@
 <!DOCTYPE html>
-<html>
+<html class="dark">
 <head>
-    <meta charset="UTF-8">
-    <title>Edit Book - PustakaPro</title>
-    <link rel="stylesheet" href="/style.css">
+  <meta charset="UTF-8" />
+  <title>Edit Book - PustakaPro</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
 </head>
-<body>
-<div class="container">
-    <header>
-        <h1>Edit Book</h1>
-        <nav>
-            <a href="/" class="button">Home</a>
-        </nav>
-    </header>
-    <form method="post" action="/edit/<%= book.id %>">
-        <label>Title:<br><input type="text" name="title" value="<%= book.title %>" required></label>
-        <label>Author:<br><input type="text" name="author" value="<%= book.author %>" required></label>
-        <label>Year:<br><input type="number" name="year" value="<%= book.year %>"></label>
-        <button type="submit">Save</button>
-    </form>
-</div>
+<body class="bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-gray-100">
+  <div id="root"></div>
+  <script type="text/babel" data-type="module" data-presets="react,typescript">
+    import Button from '/components/ui/Button.tsx';
+    import Form from '/components/ui/Form.tsx';
+
+    const book = <%- JSON.stringify(book) %>;
+
+    const App = () => (
+      <div className="max-w-md mx-auto p-4">
+        <header className="flex items-center justify-between mb-4">
+          <h1 className="text-2xl font-bold">Edit Book</h1>
+          <nav>
+            <Button onClick={() => window.location.href = '/'}>Home</Button>
+          </nav>
+        </header>
+        <Form method="post" action={`/edit/${book.id}`} submitLabel="Save">
+          <label className="block">
+            <span className="block mb-1">Title</span>
+            <input name="title" defaultValue={book.title} required className="w-full p-2 border dark:border-gray-600 rounded" />
+          </label>
+          <label className="block">
+            <span className="block mb-1">Author</span>
+            <input name="author" defaultValue={book.author} required className="w-full p-2 border dark:border-gray-600 rounded" />
+          </label>
+          <label className="block">
+            <span className="block mb-1">Year</span>
+            <input name="year" type="number" defaultValue={book.year} className="w-full p-2 border dark:border-gray-600 rounded" />
+          </label>
+        </Form>
+      </div>
+    );
+
+    const root = ReactDOM.createRoot(document.getElementById('root'));
+    root.render(<App />);
+  </script>
 </body>
 </html>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -1,40 +1,86 @@
 <!DOCTYPE html>
-<html>
+<html class="dark">
 <head>
-    <meta charset="UTF-8">
-    <title>PustakaPro Library</title>
-    <link rel="stylesheet" href="/style.css">
+  <meta charset="UTF-8" />
+  <title>PustakaPro Library</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
 </head>
-<body>
-<div class="container">
-    <header>
-        <h1>PustakaPro</h1>
-        <nav>
-            <a href="/" class="button">Home</a>
-            <a href="/add" class="button">Add Book</a>
-        </nav>
-    </header>
-    <form method="get" action="/search" class="search">
-        <input type="text" name="q" placeholder="Search books">
-        <button type="submit">Search</button>
-    </form>
-    <table>
-        <tr><th>Title</th><th>Author</th><th>Year</th><th>Actions</th></tr>
-        <% books.forEach(function(book){ %>
-            <tr>
-                <td><%= book.title %></td>
-                <td><%= book.author %></td>
-                <td><%= book.year %></td>
-                <td>
-                    <a href="/book/<%= book.id %>" class="button">View</a>
-                    <a href="/edit/<%= book.id %>" class="button">Edit</a>
-                    <form action="/delete/<%= book.id %>" method="post" class="inline">
-                        <button type="submit">Delete</button>
-                    </form>
-                </td>
-            </tr>
-        <% }); %>
-    </table>
-</div>
+<body class="bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-gray-100">
+  <div id="root"></div>
+  <script type="text/babel" data-type="module" data-presets="react,typescript">
+    import Button from '/components/ui/Button.tsx';
+    import Form from '/components/ui/Form.tsx';
+    import Table from '/components/ui/Table.tsx';
+    import Modal from '/components/ui/Modal.tsx';
+
+    const books = <%- JSON.stringify(books) %>;
+
+    const App = () => {
+      const handleSearch = (e: React.FormEvent<HTMLFormElement>) => {
+        e.preventDefault();
+        const form = e.currentTarget;
+        const q = (form.elements.namedItem('q') as HTMLInputElement).value;
+        window.location.href = `/search?q=${encodeURIComponent(q)}`;
+      };
+
+      const [open, setOpen] = React.useState(false);
+      const [selected, setSelected] = React.useState<number | null>(null);
+
+      const askDelete = (id: number) => {
+        setSelected(id);
+        setOpen(true);
+      };
+
+      const close = () => setOpen(false);
+
+      return (
+        <div className="max-w-4xl mx-auto p-4">
+          <header className="flex items-center justify-between mb-4">
+            <h1 className="text-2xl font-bold">PustakaPro</h1>
+            <nav className="space-x-2">
+              <Button onClick={() => window.location.href = '/'}>Home</Button>
+              <Button variant="secondary" onClick={() => window.location.href = '/add'}>Add Book</Button>
+            </nav>
+          </header>
+          <Form onSubmit={handleSearch} submitLabel="Search">
+            <input name="q" type="text" placeholder="Search books" className="w-full p-2 border dark:border-gray-600 rounded" />
+          </Form>
+          <div className="mt-6 overflow-x-auto">
+            <Table
+              headers={["Title", "Author", "Year", "Actions"]}
+              data={books}
+              renderRow={(book: any) => (
+                <>
+                  <td className="px-4 py-2">{book.title}</td>
+                  <td className="px-4 py-2">{book.author}</td>
+                  <td className="px-4 py-2">{book.year}</td>
+                  <td className="px-4 py-2 space-x-2">
+                    <Button size="sm" onClick={() => window.location.href = `/book/${book.id}`}>View</Button>
+                    <Button size="sm" variant="secondary" onClick={() => window.location.href = `/edit/${book.id}`}>Edit</Button>
+                    <Button size="sm" variant="danger" onClick={() => askDelete(book.id)}>Delete</Button>
+                  </td>
+                </>
+              )}
+            />
+          </div>
+          <Modal isOpen={open} title="Confirm delete" onClose={close}>
+            <p className="mb-4">Are you sure you want to delete this book?</p>
+            {selected !== null && (
+              <form method="post" action={`/delete/${selected}`} className="text-right space-x-2">
+                <Button variant="secondary" onClick={close} type="button">Cancel</Button>
+                <Button variant="danger" type="submit">Delete</Button>
+              </form>
+            )}
+          </Modal>
+        </div>
+      );
+    };
+
+    const root = ReactDOM.createRoot(document.getElementById('root'));
+    root.render(<App />);
+  </script>
 </body>
 </html>

--- a/views/show.ejs
+++ b/views/show.ejs
@@ -1,21 +1,36 @@
 <!DOCTYPE html>
-<html>
+<html class="dark">
 <head>
-    <meta charset="UTF-8">
-    <title><%= book.title %> - PustakaPro</title>
-    <link rel="stylesheet" href="/style.css">
+  <meta charset="UTF-8" />
+  <title><%= book.title %> - PustakaPro</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
 </head>
-<body>
-<div class="container">
-    <header>
-        <h1><%= book.title %></h1>
-        <nav>
-            <a href="/" class="button">Home</a>
-            <a href="/edit/<%= book.id %>" class="button">Edit</a>
-        </nav>
-    </header>
-    <p><strong>Author:</strong> <%= book.author %></p>
-    <p><strong>Year:</strong> <%= book.year %></p>
-</div>
+<body class="bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-gray-100">
+  <div id="root"></div>
+  <script type="text/babel" data-type="module" data-presets="react,typescript">
+    import Button from '/components/ui/Button.tsx';
+
+    const book = <%- JSON.stringify(book) %>;
+
+    const App = () => (
+      <div className="max-w-md mx-auto p-4">
+        <header className="flex items-center justify-between mb-4">
+          <h1 className="text-2xl font-bold">{book.title}</h1>
+          <nav className="space-x-2">
+            <Button onClick={() => window.location.href = '/'}>Home</Button>
+            <Button variant="secondary" onClick={() => window.location.href = `/edit/${book.id}`}>Edit</Button>
+          </nav>
+        </header>
+        <p><strong>Author:</strong> {book.author}</p>
+        <p><strong>Year:</strong> {book.year}</p>
+      </div>
+    );
+
+    const root = ReactDOM.createRoot(document.getElementById('root'));
+    root.render(<App />);
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add Button, Modal, Table, and Form React components styled with Tailwind and accessible for keyboard users
- render shared components across EJS pages and serve them statically via Express
- include delete confirmation modal and dark-mode styling for consistent UX

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68ad6fe23a708322b64f5e587a76a5f9