### PR TITLE
feat: add email reminders and overdue notifications

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,12 @@
 # Copy this file to .env and set the values for your environment
 PORT=3000
 DB_FILE=library.db
+# SMTP configuration for email utility
+SMTP_HOST=localhost
+SMTP_PORT=587
+SMTP_USER=username
+SMTP_PASS=password
+SMTP_FROM=library@example.com
+
+# Days before due date to send reminder
+REMINDER_DAYS=3

--- a/app.js
+++ b/app.js
@@ -5,6 +5,7 @@ const sqlite3 = require('sqlite3').verbose();
 const bodyParser = require('body-parser');
 const morgan = require('morgan');
 const helmet = require('helmet');
+const scheduler = require('./lib/scheduler');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -18,7 +19,7 @@ app.use(bodyParser.urlencoded({ extended: false }));
 app.use(helmet());
 app.use(morgan('combined'));
 
-// initialize database table
+// initialize database tables
 const initSql = `CREATE TABLE IF NOT EXISTS books(
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     title TEXT NOT NULL,
@@ -26,8 +27,20 @@ const initSql = `CREATE TABLE IF NOT EXISTS books(
     year INTEGER
 );`;
 
-db.run(initSql, (err) => {
-    if (err) console.error('Failed to initialize database', err);
+const borrowSql = `CREATE TABLE IF NOT EXISTS borrows(
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    bookId INTEGER NOT NULL,
+    userEmail TEXT NOT NULL,
+    dueDate TEXT NOT NULL,
+    locale TEXT DEFAULT 'en',
+    fine REAL DEFAULT 0,
+    returned INTEGER DEFAULT 0,
+    FOREIGN KEY(bookId) REFERENCES books(id)
+);`;
+
+db.serialize(() => {
+    db.run(initSql);
+    db.run(borrowSql);
 });
 
 // routes
@@ -95,6 +108,51 @@ app.post('/delete/:id', (req, res) => {
         if (err) return res.status(500).send(err.toString());
         res.redirect('/');
     });
+});
+
+// borrow a book
+app.post('/borrow', (req, res) => {
+    const { bookId, userEmail, dueDate, locale } = req.body;
+    db.run('INSERT INTO borrows(bookId, userEmail, dueDate, locale) VALUES(?, ?, ?, ?)',
+        [bookId, userEmail, dueDate, locale || 'en'], function (err) {
+            if (err) return res.status(500).send(err.toString());
+            // fetch book title for email templates
+            db.get('SELECT title FROM books WHERE id = ?', [bookId], (e2, row) => {
+                if (e2) return res.status(500).send(e2.toString());
+                scheduler.scheduleBorrowReminder({
+                    id: this.lastID,
+                    bookId,
+                    title: row ? row.title : '',
+                    userEmail,
+                    dueDate,
+                    locale: locale || 'en'
+                }, parseInt(process.env.REMINDER_DAYS || '3', 10));
+                res.redirect('/');
+            });
+        });
+});
+
+// impose a fine on a borrow
+app.post('/borrows/:id/fine', (req, res) => {
+    const id = req.params.id;
+    const amount = Number(req.body.amount || 0);
+    db.get(
+        'SELECT b.*, bk.title FROM borrows b JOIN books bk ON b.bookId = bk.id WHERE b.id = ?',
+        [id],
+        (err, borrow) => {
+            if (err) return res.status(500).send(err.toString());
+            if (!borrow) return res.status(404).send('Borrow not found');
+            db.run('UPDATE borrows SET fine = ? WHERE id = ?', [amount, id], (e2) => {
+                if (e2) return res.status(500).send(e2.toString());
+                scheduler.scheduleFineNotice({
+                    title: borrow.title,
+                    userEmail: borrow.userEmail,
+                    locale: borrow.locale
+                }, amount);
+                res.send('Fine imposed');
+            });
+        }
+    );
 });
 
 // 404 handler

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -1,0 +1,47 @@
+const nodemailer = require('nodemailer');
+
+// create transporter using SMTP values from environment
+const transporter = nodemailer.createTransport({
+  host: process.env.SMTP_HOST,
+  port: Number(process.env.SMTP_PORT || 587),
+  auth: {
+    user: process.env.SMTP_USER,
+    pass: process.env.SMTP_PASS,
+  }
+});
+
+const templates = {
+  en: {
+    reminder: ({ title, dueDate }) => `Reminder: Return "${title}" by ${dueDate.toDateString()}`,
+    overdue: ({ title, dueDate }) => `Overdue: "${title}" was due on ${dueDate.toDateString()}`,
+    fine: ({ title, amount }) => `Fine imposed on "${title}". Amount due: $${amount}`
+  }
+};
+
+function render(template, locale, data) {
+  const strings = templates[locale] || templates.en;
+  return strings[template](data);
+}
+
+function sendMail(to, subject, html) {
+  return transporter.sendMail({
+    from: process.env.SMTP_FROM || process.env.SMTP_USER,
+    to,
+    subject,
+    html
+  });
+}
+
+function sendReminder(to, data, locale = 'en') {
+  return sendMail(to, 'Library Reminder', render('reminder', locale, data));
+}
+
+function sendOverdue(to, data, locale = 'en') {
+  return sendMail(to, 'Book Overdue', render('overdue', locale, data));
+}
+
+function sendFine(to, data, locale = 'en') {
+  return sendMail(to, 'Fine Notice', render('fine', locale, data));
+}
+
+module.exports = { sendReminder, sendOverdue, sendFine };

--- a/lib/scheduler.ts
+++ b/lib/scheduler.ts
@@ -1,0 +1,32 @@
+const cron = require('node-cron');
+const email = require('./email');
+
+function toCron(date) {
+  return `${date.getMinutes()} ${date.getHours()} ${date.getDate()} ${date.getMonth() + 1} *`;
+}
+
+function scheduleBorrowReminder(borrow, daysBefore = 3) {
+  const dueDate = new Date(borrow.dueDate);
+  const reminderDate = new Date(dueDate);
+  reminderDate.setDate(reminderDate.getDate() - daysBefore);
+
+  const reminderCron = toCron(reminderDate);
+  const reminderTask = cron.schedule(reminderCron, () => {
+    email.sendReminder(borrow.userEmail, { title: borrow.title, dueDate }, borrow.locale);
+    reminderTask.stop();
+  });
+
+  const overdueCron = toCron(dueDate);
+  const overdueTask = cron.schedule(overdueCron, () => {
+    email.sendOverdue(borrow.userEmail, { title: borrow.title, dueDate }, borrow.locale);
+    overdueTask.stop();
+  });
+
+  return { reminderTask, overdueTask };
+}
+
+function scheduleFineNotice(borrow, amount) {
+  return email.sendFine(borrow.userEmail, { title: borrow.title, amount }, borrow.locale);
+}
+
+module.exports = { scheduleBorrowReminder, scheduleFineNotice };

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,8 @@
         "express": "^5.1.0",
         "helmet": "^7.0.0",
         "morgan": "^1.10.0",
+        "node-cron": "^3.0.3",
+        "nodemailer": "^6.9.11",
         "sqlite3": "^5.1.7"
       }
     },
@@ -1556,6 +1558,18 @@
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
       "license": "MIT"
     },
+    "node_modules/node-cron": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-3.0.3.tgz",
+      "integrity": "sha512-dOal67//nohNgYWb+nWmg5dkFdIwDm8EpeGYMekPMrngV3637lqnX0lbUcCtgibHTz6SEz7DAIjKvKDFYCnO1A==",
+      "license": "ISC",
+      "dependencies": {
+        "uuid": "8.3.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/node-gyp": {
       "version": "8.4.1",
       "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-8.4.1.tgz",
@@ -1579,6 +1593,15 @@
       },
       "engines": {
         "node": ">= 10.12.0"
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
+      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/nopt": {
@@ -2374,6 +2397,15 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
     },
     "node_modules/vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "sqlite3": "^5.1.7",
     "dotenv": "^16.3.1",
     "helmet": "^7.0.0",
-    "morgan": "^1.10.0"
+    "morgan": "^1.10.0",
+    "nodemailer": "^6.9.11",
+    "node-cron": "^3.0.3"
   }
 }


### PR DESCRIPTION
## Summary
- add nodemailer-based email utility with localized templates
- schedule due date reminders and overdue notices using node-cron
- send fine notifications and expose new borrow/fine routes

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68ad6fdeb4948322b9f65ca8b6b0d63b