### PR TITLE
feat: add borrow management

### DIFF
--- a/app.js
+++ b/app.js
@@ -15,6 +15,7 @@ app.set('view engine', 'ejs');
 app.set('views', path.join(__dirname, 'views'));
 app.use(express.static(path.join(__dirname, 'public')));
 app.use(bodyParser.urlencoded({ extended: false }));
+app.use(bodyParser.json());
 app.use(helmet());
 app.use(morgan('combined'));
 
@@ -28,6 +29,21 @@ const initSql = `CREATE TABLE IF NOT EXISTS books(
 
 db.run(initSql, (err) => {
     if (err) console.error('Failed to initialize database', err);
+});
+
+// initialize borrows table
+const borrowSql = `CREATE TABLE IF NOT EXISTS borrows(
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    book_id INTEGER,
+    user_id TEXT,
+    borrowDate TEXT,
+    dueDate TEXT,
+    returnDate TEXT,
+    fine REAL DEFAULT 0
+);`;
+
+db.run(borrowSql, (err) => {
+    if (err) console.error('Failed to initialize borrows table', err);
 });
 
 // routes
@@ -96,6 +112,10 @@ app.post('/delete/:id', (req, res) => {
         res.redirect('/');
     });
 });
+
+// borrow management routes
+app.use('/api/borrows', require('./app/api/borrows'));
+app.use('/borrows', require('./app/borrows'));
 
 // 404 handler
 app.use((req, res) => {

--- a/app/api/borrows/index.js
+++ b/app/api/borrows/index.js
@@ -1,0 +1,62 @@
+const express = require('express');
+const sqlite3 = require('sqlite3').verbose();
+const router = express.Router();
+
+const DB_FILE = process.env.DB_FILE || 'library.db';
+const DAILY_RATE = parseFloat(process.env.DAILY_RATE || '1');
+
+const db = new sqlite3.Database(DB_FILE);
+
+// Borrow a book
+router.post('/borrow', (req, res) => {
+  const { bookId, userId } = req.body;
+  if (!bookId || !userId) return res.status(400).json({ error: 'bookId and userId required' });
+  const borrowDate = new Date();
+  const dueDate = new Date(borrowDate);
+  dueDate.setDate(dueDate.getDate() + 14);
+  db.run(
+    'INSERT INTO borrows(book_id, user_id, borrowDate, dueDate, returnDate, fine) VALUES (?,?,?,?,?,?)',
+    [bookId, userId, borrowDate.toISOString(), dueDate.toISOString(), null, 0],
+    function (err) {
+      if (err) return res.status(500).json({ error: err.message });
+      res.json({ id: this.lastID, bookId, userId, borrowDate, dueDate, returnDate: null, fine: 0 });
+    }
+  );
+});
+
+// Return a book
+router.post('/return/:id', (req, res) => {
+  const id = req.params.id;
+  const returnDate = new Date();
+  db.get('SELECT dueDate FROM borrows WHERE id=?', [id], (err, row) => {
+    if (err) return res.status(500).json({ error: err.message });
+    if (!row) return res.status(404).json({ error: 'Borrow record not found' });
+    const dueDate = new Date(row.dueDate);
+    const daysLate = Math.ceil((returnDate - dueDate) / (1000 * 60 * 60 * 24));
+    const fine = daysLate > 0 ? daysLate * DAILY_RATE : 0;
+    db.run(
+      'UPDATE borrows SET returnDate=?, fine=? WHERE id=?',
+      [returnDate.toISOString(), fine, id],
+      function (err2) {
+        if (err2) return res.status(500).json({ error: err2.message });
+        res.json({ id, returnDate, fine });
+      }
+    );
+  });
+});
+
+// Calculate fine for a borrow (without returning)
+router.get('/fine/:id', (req, res) => {
+  const id = req.params.id;
+  db.get('SELECT dueDate, returnDate FROM borrows WHERE id=?', [id], (err, row) => {
+    if (err) return res.status(500).json({ error: err.message });
+    if (!row) return res.status(404).json({ error: 'Borrow record not found' });
+    const refDate = row.returnDate ? new Date(row.returnDate) : new Date();
+    const dueDate = new Date(row.dueDate);
+    const daysLate = Math.ceil((refDate - dueDate) / (1000 * 60 * 60 * 24));
+    const fine = daysLate > 0 ? daysLate * DAILY_RATE : 0;
+    res.json({ id, fine });
+  });
+});
+
+module.exports = router;

--- a/app/borrows/index.js
+++ b/app/borrows/index.js
@@ -1,0 +1,55 @@
+const express = require('express');
+const sqlite3 = require('sqlite3').verbose();
+const router = express.Router();
+
+const DB_FILE = process.env.DB_FILE || 'library.db';
+const DAILY_RATE = parseFloat(process.env.DAILY_RATE || '1');
+const db = new sqlite3.Database(DB_FILE);
+
+// list borrows
+router.get('/', (req, res) => {
+  db.all('SELECT * FROM borrows', [], (err, rows) => {
+    if (err) return res.status(500).send(err.toString());
+    res.render('borrows', { borrows: rows });
+  });
+});
+
+// handle borrow from form
+router.post('/borrow', (req, res) => {
+  const { bookId, userId } = req.body;
+  if (!bookId || !userId) return res.status(400).send('bookId and userId required');
+  const borrowDate = new Date();
+  const dueDate = new Date(borrowDate);
+  dueDate.setDate(dueDate.getDate() + 14);
+  db.run(
+    'INSERT INTO borrows(book_id, user_id, borrowDate, dueDate, returnDate, fine) VALUES (?,?,?,?,?,?)',
+    [bookId, userId, borrowDate.toISOString(), dueDate.toISOString(), null, 0],
+    err => {
+      if (err) return res.status(500).send(err.toString());
+      res.redirect('/borrows');
+    }
+  );
+});
+
+// handle return from form
+router.post('/return/:id', (req, res) => {
+  const id = req.params.id;
+  const returnDate = new Date();
+  db.get('SELECT dueDate FROM borrows WHERE id=?', [id], (err, row) => {
+    if (err) return res.status(500).send(err.toString());
+    if (!row) return res.status(404).send('Borrow record not found');
+    const dueDate = new Date(row.dueDate);
+    const daysLate = Math.ceil((returnDate - dueDate) / (1000 * 60 * 60 * 24));
+    const fine = daysLate > 0 ? daysLate * DAILY_RATE : 0;
+    db.run(
+      'UPDATE borrows SET returnDate=?, fine=? WHERE id=?',
+      [returnDate.toISOString(), fine, id],
+      err2 => {
+        if (err2) return res.status(500).send(err2.toString());
+        res.redirect('/borrows');
+      }
+    );
+  });
+});
+
+module.exports = router;

--- a/models/Borrow.ts
+++ b/models/Borrow.ts
@@ -1,0 +1,9 @@
+export interface Borrow {
+  id?: number;
+  bookId: number;
+  userId: string;
+  borrowDate: string;
+  dueDate: string;
+  returnDate?: string | null;
+  fine: number;
+}

--- a/views/borrows.ejs
+++ b/views/borrows.ejs
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Borrow Records</title>
+  <link rel="stylesheet" href="/styles.css" />
+</head>
+<body>
+  <h1>Borrow Records</h1>
+
+  <h2>Borrow a Book</h2>
+  <form action="/borrows/borrow" method="POST">
+    <input type="number" name="bookId" placeholder="Book ID" required />
+    <input type="text" name="userId" placeholder="User ID" required />
+    <button type="submit">Borrow</button>
+  </form>
+
+  <h2>Current Borrows</h2>
+  <table border="1" cellpadding="5">
+    <tr>
+      <th>ID</th>
+      <th>Book ID</th>
+      <th>User ID</th>
+      <th>Borrow Date</th>
+      <th>Due Date</th>
+      <th>Return Date</th>
+      <th>Fine</th>
+      <th>Action</th>
+    </tr>
+    <% borrows.forEach(b => { %>
+      <tr>
+        <td><%= b.id %></td>
+        <td><%= b.book_id %></td>
+        <td><%= b.user_id %></td>
+        <td><%= b.borrowDate %></td>
+        <td><%= b.dueDate %></td>
+        <td><%= b.returnDate || '' %></td>
+        <td><%= b.fine %></td>
+        <td>
+          <% if (!b.returnDate) { %>
+            <form action="/borrows/return/<%= b.id %>" method="POST">
+              <button type="submit">Return</button>
+            </form>
+          <% } %>
+        </td>
+      </tr>
+    <% }) %>
+  </table>
+
+  <p><a href="/">Back to home</a></p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- model borrow transactions with book, user, dates and fines
- provide API endpoints to borrow, return, and calculate fines
- add UI to manage and view borrowing transactions

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68ad6fd4bad8832284d163e63adbcb49